### PR TITLE
Adds Docker image building support.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,3 +16,15 @@ build: clean
 clean:
 	rm -rf ./bin
 	rm -rf ./tmp
+
+# Commands for docker images.
+# ----------------------------
+build-linux:
+	GOOS=linux GOARCH=amd64 go build -v -o ./bin/executor ./cmd/executor
+	GOOS=linux GOARCH=amd64 go build -v -o ./bin/ordermatch ./cmd/ordermatch
+	GOOS=linux GOARCH=amd64 go build -v -o ./bin/tradeclient ./cmd/tradeclient
+
+build-docker: clean build-linux
+	docker build -t quickfixgo/executor:latest -f ./cmd/executor/Dockerfile .
+	docker build -t quickfixgo/ordermatch:latest -f ./cmd/ordermatch/Dockerfile .
+	docker build -t quickfixgo/tradeclient:latest -f ./cmd/tradeclient/Dockerfile .

--- a/cmd/executor/Dockerfile
+++ b/cmd/executor/Dockerfile
@@ -1,0 +1,7 @@
+FROM golang:alpine
+
+ADD config config
+
+ADD bin/executor /executor
+
+ENTRYPOINT ["/executor"]

--- a/cmd/ordermatch/Dockerfile
+++ b/cmd/ordermatch/Dockerfile
@@ -1,0 +1,7 @@
+FROM golang:alpine
+
+ADD config config
+
+ADD bin/ordermatch /ordermatch
+
+ENTRYPOINT ["/ordermatch"]

--- a/cmd/tradeclient/Dockerfile
+++ b/cmd/tradeclient/Dockerfile
@@ -1,0 +1,7 @@
+FROM golang:alpine
+
+ADD config config
+
+ADD bin/tradeclient /tradeclient
+
+ENTRYPOINT ["/tradeclient"]


### PR DESCRIPTION
Resolves https://github.com/quickfixgo/examples/issues/15
- To make these publicly available, run `make build-docker` to build the docker images then push them to a quickfixgo organization on hub.docker.com
- I'm open to potentially adding goreleaser for publishing docker images. It also automates other types of release publishing too (e.g- install examples via homebrew).