### PR TITLE
Update ordermatch to fix 5.0 and fix error to cancel orders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ vendor
 bin
 .exe
 dist/
+.idea

--- a/Makefile
+++ b/Makefile
@@ -23,3 +23,9 @@ build-linux:
 
 build-docker: clean build-linux
 	docker build -t quickfixgo/qf:latest .
+
+run-client:
+	./bin/qf tradeclient ./config/tradeclient.cfg
+
+run-server:
+	./bin/qf ordermatch ./config/ordermatch.cfg

--- a/cmd/ordermatch/internal/market.go
+++ b/cmd/ordermatch/internal/market.go
@@ -101,7 +101,7 @@ func (m Market) Display() {
 		fmt.Printf("%+v\n", bid)
 	}
 
-	fmt.Println("OFFERS:")
+	fmt.Println("ASKS:")
 	fmt.Println("-----")
 	fmt.Println()
 

--- a/cmd/ordermatch/ordermatch.go
+++ b/cmd/ordermatch/ordermatch.go
@@ -30,10 +30,10 @@ import (
 	"github.com/quickfixgo/examples/cmd/ordermatch/internal"
 	"github.com/quickfixgo/examples/cmd/utils"
 	"github.com/quickfixgo/field"
-	"github.com/quickfixgo/fix42/executionreport"
-	"github.com/quickfixgo/fix42/marketdatarequest"
-	"github.com/quickfixgo/fix42/newordersingle"
-	"github.com/quickfixgo/fix42/ordercancelrequest"
+	"github.com/quickfixgo/fix50/executionreport"
+	"github.com/quickfixgo/fix50/marketdatarequest"
+	"github.com/quickfixgo/fix50/newordersingle"
+	"github.com/quickfixgo/fix50/ordercancelrequest"
 	"github.com/spf13/cobra"
 
 	"github.com/quickfixgo/quickfix"
@@ -62,7 +62,9 @@ func newApplication() *Application {
 func (a Application) OnCreate(sessionID quickfix.SessionID) {}
 
 // OnLogon implemented as part of Application interface
-func (a Application) OnLogon(sessionID quickfix.SessionID) {}
+func (a Application) OnLogon(sessionID quickfix.SessionID) {
+
+}
 
 // OnLogout implemented as part of Application interface
 func (a Application) OnLogout(sessionID quickfix.SessionID) {}
@@ -204,21 +206,21 @@ func (a *Application) updateOrder(order internal.Order, status enum.OrdStatus) {
 	execReport := executionreport.New(
 		field.NewOrderID(order.ClOrdID),
 		field.NewExecID(a.genExecID()),
-		field.NewExecTransType(enum.ExecTransType_NEW),
 		field.NewExecType(enum.ExecType(status)),
 		field.NewOrdStatus(status),
-		field.NewSymbol(order.Symbol),
 		field.NewSide(order.Side),
 		field.NewLeavesQty(order.OpenQuantity(), 2),
 		field.NewCumQty(order.ExecutedQuantity, 2),
-		field.NewAvgPx(order.AvgPx, 2),
 	)
-	execReport.SetOrderQty(order.Quantity, 2)
+
 	execReport.SetClOrdID(order.ClOrdID)
+	execReport.SetSymbol(order.Symbol)
+	execReport.SetOrderQty(order.Quantity, 2)
+	execReport.SetAvgPx(order.AvgPx, 2)
 
 	switch status {
 	case enum.OrdStatus_FILLED, enum.OrdStatus_PARTIALLY_FILLED:
-		execReport.SetLastShares(order.LastExecutedQuantity, 2)
+		execReport.SetLastQty(order.LastExecutedQuantity, 2)
 		execReport.SetLastPx(order.LastExecutedPrice, 2)
 	}
 

--- a/cmd/tradeclient/internal/console.go
+++ b/cmd/tradeclient/internal/console.go
@@ -137,7 +137,7 @@ func queryClOrdID() field.ClOrdIDField {
 }
 
 func queryOrigClOrdID() field.OrigClOrdIDField {
-	return field.NewOrigClOrdID(("OrigClOrdID"))
+	return field.NewOrigClOrdID(queryString("OrigClOrdID"))
 }
 
 func querySymbol() field.SymbolField {
@@ -207,15 +207,17 @@ func queryTimeInForce() field.TimeInForceField {
 }
 
 func queryOrderQty() field.OrderQtyField {
-	return field.NewOrderQty(queryDecimal("OrderQty"), 2)
+	dec := queryDecimal("OrderQty").Truncate(8)
+	return field.NewOrderQty(dec, 8)
 }
 
 func queryPrice() field.PriceField {
-	return field.NewPrice(queryDecimal("Price"), 2)
+	dec := queryDecimal("Price").Truncate(8)
+	return field.NewPrice(dec, 8)
 }
 
 func queryStopPx() field.StopPxField {
-	return field.NewStopPx(queryDecimal("Stop Price"), 2)
+	return field.NewStopPx(queryDecimal("Stop Price"), 8)
 }
 
 func querySenderCompID() field.SenderCompIDField {
@@ -370,7 +372,6 @@ func queryNewOrderSingle50() (msg *quickfix.Message) {
 	order.SetHandlInst("1")
 	order.Set(querySymbol())
 	order.Set(queryOrderQty())
-	order.Set(queryTimeInForce())
 
 	switch ordType.Value() {
 	case enum.OrdType_LIMIT, enum.OrdType_STOP_LIMIT:
@@ -381,6 +382,8 @@ func queryNewOrderSingle50() (msg *quickfix.Message) {
 	case enum.OrdType_STOP, enum.OrdType_STOP_LIMIT:
 		order.Set(queryStopPx())
 	}
+
+	order.Set(queryTimeInForce())
 
 	msg = order.ToMessage()
 	queryHeader(&msg.Header)

--- a/cmd/tradeclient/tradeclient.go
+++ b/cmd/tradeclient/tradeclient.go
@@ -34,10 +34,12 @@ type TradeClient struct {
 }
 
 // OnCreate implemented as part of Application interface
-func (e TradeClient) OnCreate(sessionID quickfix.SessionID) {}
+func (e TradeClient) OnCreate(sessionID quickfix.SessionID) {
+}
 
 // OnLogon implemented as part of Application interface
-func (e TradeClient) OnLogon(sessionID quickfix.SessionID) {}
+func (e TradeClient) OnLogon(sessionID quickfix.SessionID) {
+}
 
 // OnLogout implemented as part of Application interface
 func (e TradeClient) OnLogout(sessionID quickfix.SessionID) {}


### PR DESCRIPTION
- Update ordermatch parser to use fix protocol 5.0
- Fix the problem of canceling an order, because the parser doesn't get `OrigClOrdID `
- Improve makefile to run server and client easily
- Change print to ASKS and add truncate/scale to 8 decimals, it's more common in the market 