### PR TITLE
Added missing queryString method on OrigClOrdID parameter

### DIFF
--- a/cmd/tradeclient/internal/console.go
+++ b/cmd/tradeclient/internal/console.go
@@ -137,7 +137,7 @@ func queryClOrdID() field.ClOrdIDField {
 }
 
 func queryOrigClOrdID() field.OrigClOrdIDField {
-	return field.NewOrigClOrdID(("OrigClOrdID"))
+	return field.NewOrigClOrdID(queryString("OrigClOrdID"))
 }
 
 func querySymbol() field.SymbolField {


### PR DESCRIPTION
Hello, I found out missing `queryString` method on console.go file. 
Please, accept it. 