### PR TITLE
ExecType Fill is replaced with Trade in FIX 4.3

### DIFF
--- a/cmd/executor/executor.go
+++ b/cmd/executor/executor.go
@@ -319,7 +319,7 @@ func (e *executor) OnFIX43NewOrderSingle(msg fix43nos.NewOrderSingle, sessionID 
 	execReport := fix43er.New(
 		e.genOrderID(),
 		e.genExecID(),
-		field.NewExecType(enum.ExecType_FILL),
+		field.NewExecType(enum.ExecType_TRADE),
 		field.NewOrdStatus(enum.OrdStatus_FILLED),
 		field.NewSide(side),
 		field.NewLeavesQty(decimal.Zero, 2),
@@ -388,7 +388,7 @@ func (e *executor) OnFIX44NewOrderSingle(msg fix44nos.NewOrderSingle, sessionID 
 	execReport := fix44er.New(
 		e.genOrderID(),
 		e.genExecID(),
-		field.NewExecType(enum.ExecType_FILL),
+		field.NewExecType(enum.ExecType_TRADE),
 		field.NewOrdStatus(enum.OrdStatus_FILLED),
 		field.NewSide(side),
 		field.NewLeavesQty(decimal.Zero, 2),
@@ -457,7 +457,7 @@ func (e *executor) OnFIX50NewOrderSingle(msg fix50nos.NewOrderSingle, sessionID 
 	execReport := fix50er.New(
 		e.genOrderID(),
 		e.genExecID(),
-		field.NewExecType(enum.ExecType_FILL),
+		field.NewExecType(enum.ExecType_TRADE),
 		field.NewOrdStatus(enum.OrdStatus_FILLED),
 		field.NewSide(side),
 		field.NewLeavesQty(decimal.Zero, 2),


### PR DESCRIPTION
When testing FIX 4.4+ connections with an AppDataDictionary, the Execution Report `ExecType` tag value results in a message reject: `Value is incorrect (out of range) for this tag`. Looking at [Appendix 6-F. Replaced Features and Supported Approach](https://www.onixs.biz/fix-dictionary/4.3/app_6_f.html#1) and confirming with the tag values in the XML files from [quickfixgo's spec folder](https://github.com/quickfixgo/quickfix/tree/main/spec), `ExecType_FILL` is no longer a valid enum value.

Sorry for sending a PR out of the blue. Let me know if you'd like me to make any changes.